### PR TITLE
Add concurrent dev script

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,2 +1,12 @@
-#!/bin/bash
-echo "dev script"
+#!/usr/bin/env bash
+set -e
+
+# Determine repository root
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Run Miniflare, Laravel and Plasmo extension concurrently
+npx concurrently -k \
+  "cd edge-api && npx wrangler dev" \
+  "cd api && php artisan serve" \
+  "cd extension && npx plasmo dev"


### PR DESCRIPTION
## Summary
- update dev.sh to run wrangler, artisan and plasmo in parallel

## Testing
- `bash -n scripts/dev.sh`
- `npx --yes concurrently --version`
- `npx --yes plasmo --version`
- `npx --yes wrangler dev --help | head -n 20` *(fails: domain `sparrow.cloudflare.com` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857100300fc8321903b698b93a1de50