### PR TITLE
Implement minimal extension UI

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .dist
 build
+.plasmo

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -1,3 +1,58 @@
+import { useState } from "react"
+import "./style.css"
+
 export default function Popup() {
-  return <div>Listing Optimizer Popup</div>;
+  const [status, setStatus] = useState<"idle" | "loading" | "ready">("idle")
+  const [title, setTitle] = useState("")
+
+  const handleScan = () => {
+    setStatus("loading")
+    // Mock API call
+    setTimeout(() => {
+      setTitle("Optimized Listing Title")
+      setStatus("ready")
+    }, 1000)
+  }
+
+  const handleApply = () => {
+    // Mock apply call
+    setStatus("idle")
+    setTitle("")
+  }
+
+  return (
+    <div className="w-72 p-4 text-gray-800 font-sans">
+      <h1 className="text-lg font-semibold mb-3">Listing Optimizer</h1>
+      <button
+        className="w-full bg-blue-600 text-white py-2 rounded disabled:opacity-50"
+        onClick={handleScan}
+        disabled={status === "loading"}
+      >
+        {status === "loading" ? "Scanning..." : "Scan Listings"}
+      </button>
+
+      {status === "ready" && (
+        <div className="mt-4">
+          <p className="text-sm mb-1">Suggested Title</p>
+          <div className="border p-2 rounded bg-gray-50 text-sm">{title}</div>
+          <button
+            className="mt-3 w-full bg-green-600 text-white py-2 rounded"
+            onClick={handleApply}
+          >
+            Apply
+          </button>
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-between text-xs text-gray-600">
+        <span>Quota: 10 left</span>
+        <button
+          className="text-blue-600 hover:underline"
+          onClick={() => window.open("https://example.com")}
+        >
+          Upgrade
+        </button>
+      </div>
+    </div>
+  )
 }

--- a/extension/src/side-panel.tsx
+++ b/extension/src/side-panel.tsx
@@ -1,3 +1,9 @@
+import Popup from "./popup"
+
 export default function SidePanel() {
-  return <div>Side Panel</div>;
+  return (
+    <div className="p-2">
+      <Popup />
+    </div>
+  )
 }

--- a/extension/src/style.css
+++ b/extension/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- style popup with Tailwind CSS
- reuse popup UI in the side panel
- ignore generated `.plasmo` folder

## Testing
- `npm run lint`
- `npm run build` *(fails: Error fetching package information for "plasmo" and missing icon)*

------
https://chatgpt.com/codex/tasks/task_e_68581135ec00832195094874bcb2eb37